### PR TITLE
fix_bug_array_in_json: Add test array in parenthesis

### DIFF
--- a/src/test/java/org/mvel2/tests/core/TbExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbExpressionsTest.java
@@ -776,6 +776,34 @@ public class TbExpressionsTest extends TestCase {
         assertEquals(expected, actual);
     }
 
+    public void testMapKeySetArrayInJson() {
+        String scriptBodyTestKeySetOkStr = "var data = {};\n" +
+                "data[\"devName\"] = \"devA\";\n" +
+                "var key = data.keySet().toArray()[0];\n" +
+                "return {\n" +
+                "        key: key\n" +
+                "};";
+
+        String scriptBodyTestKeySetWithoutParenthesisStr = "var data = {};\n" +
+                "data[\"devName\"] = \"devA\";\n" +
+                "return {\n" +
+                "        key: data.keySet().toArray()[0]\n" +
+                "};";
+
+        String scriptBodyTestKeySetInParenthesisStr = "var data = {};\n" +
+                "data[\"devName\"] = \"devA\";\n" +
+                "return {\n" +
+                "        key: (data.keySet().toArray()[0])\n" +
+                "};";
+
+        Object actualWithoutParenthesis = executeScript(scriptBodyTestKeySetWithoutParenthesisStr);
+        Object actualInParenthesis = executeScript(scriptBodyTestKeySetInParenthesisStr);
+        Object expected = executeScript(scriptBodyTestKeySetOkStr);
+
+        assertFalse(expected.equals(actualWithoutParenthesis));
+        assertEquals(expected, actualInParenthesis);
+    }
+
     private Object executeScript(String ex, Map vars, ExecutionContext executionContext, long timeoutMs) throws Exception {
         final CountDownLatch countDown = new CountDownLatch(1);
         AtomicReference<Object> result = new AtomicReference<>();


### PR DESCRIPTION
https://github.com/thingsboard/tbel/issues/8
Solution: Add parentheses around the entire expression
Add "("xxx")" 
```
var data = decodeToJson(payload);
var key = data.keySet().toArray()[0];
return {msg: data, metadata: metadata, (key: data.keySet().toArray()[0)]};
```