### PR TITLE
[fix_bug][3.6] stringToBytes, if the type of the input value does not match …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.thingsboard</groupId>
     <artifactId>tbel</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
 
     <name>tbel</name>
     <url>https://thingsboard.io/</url>

--- a/src/main/java/org/mvel2/ParserConfiguration.java
+++ b/src/main/java/org/mvel2/ParserConfiguration.java
@@ -18,6 +18,14 @@
 
 package org.mvel2;
 
+import org.mvel2.ast.Proto;
+import org.mvel2.compiler.AbstractParser;
+import org.mvel2.integration.Interceptor;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ClassImportResolverFactory;
+import org.mvel2.integration.impl.StackResetResolverFactory;
+import org.mvel2.util.MethodStub;
+
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -31,14 +39,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.mvel2.ast.Proto;
-import org.mvel2.compiler.AbstractParser;
-import org.mvel2.integration.Interceptor;
-import org.mvel2.integration.VariableResolverFactory;
-import org.mvel2.integration.impl.ClassImportResolverFactory;
-import org.mvel2.integration.impl.StackResetResolverFactory;
-import org.mvel2.util.MethodStub;
-
 import static org.mvel2.util.ParseTools.forNameWithInner;
 
 /**
@@ -47,6 +47,7 @@ import static org.mvel2.util.ParseTools.forNameWithInner;
 public class ParserConfiguration implements Serializable {
 
   protected final Map<String, Object> imports = new ConcurrentHashMap<String, Object>();
+  protected final Map<String, Object> reserved = new ConcurrentHashMap<String, Object>();
   protected HashSet<String> packageImports;
   protected Map<String, Interceptor> interceptors;
   protected transient ClassLoader classLoader;
@@ -179,6 +180,9 @@ public class ParserConfiguration implements Serializable {
         AbstractParser.CLASS_LITERALS.containsKey(name) ||
         checkForDynamicImport(name);
   }
+  public boolean hasReserved(String name) {
+    return reserved.containsKey(name);
+  }
 
   public void addImport(Class cls) {
     addImport(cls.getSimpleName(), cls);
@@ -186,6 +190,9 @@ public class ParserConfiguration implements Serializable {
 
   public void addImport(String name, Class cls) {
     this.imports.put(name, cls);
+  }
+  public void addReserved(String name, Class cls) {
+    this.reserved.put(name, cls);
   }
 
   public void addImport(String name, Proto proto) {
@@ -210,6 +217,9 @@ public class ParserConfiguration implements Serializable {
 
   public Map<String, Object> getImports() {
     return imports;
+  }
+  public Map<String, Object> getReserved() {
+    return reserved;
   }
 
   public void setImports(Map<String, Object> imports) {

--- a/src/main/java/org/mvel2/ParserConfiguration.java
+++ b/src/main/java/org/mvel2/ParserConfiguration.java
@@ -47,7 +47,7 @@ import static org.mvel2.util.ParseTools.forNameWithInner;
 public class ParserConfiguration implements Serializable {
 
   protected final Map<String, Object> imports = new ConcurrentHashMap<String, Object>();
-  protected final Set<String> reserved = new HashSet<>();
+  protected final Set<String> nonConvertableClasses = new HashSet<>();
   protected HashSet<String> packageImports;
   protected Map<String, Interceptor> interceptors;
   protected transient ClassLoader classLoader;
@@ -180,8 +180,8 @@ public class ParserConfiguration implements Serializable {
         AbstractParser.CLASS_LITERALS.containsKey(name) ||
         checkForDynamicImport(name);
   }
-  public boolean hasReserved(String name) {
-    return reserved.contains(name);
+  public boolean hasNonConvertableClasses(String clazz) {
+    return nonConvertableClasses.contains(clazz);
   }
 
   public void addImport(Class cls) {
@@ -191,8 +191,8 @@ public class ParserConfiguration implements Serializable {
   public void addImport(String name, Class cls) {
     this.imports.put(name, cls);
   }
-  public void addReserved(String name) {
-    this.reserved.add(name);
+  public void addNonConvertableClasses(String clazz) {
+    this.nonConvertableClasses.add(clazz);
   }
 
   public void addImport(String name, Proto proto) {
@@ -218,8 +218,8 @@ public class ParserConfiguration implements Serializable {
   public Map<String, Object> getImports() {
     return imports;
   }
-  public Set<String> getReserved() {
-    return reserved;
+  public Set<String> getNonConvertableClasses() {
+    return nonConvertableClasses;
   }
 
   public void setImports(Map<String, Object> imports) {

--- a/src/main/java/org/mvel2/ParserConfiguration.java
+++ b/src/main/java/org/mvel2/ParserConfiguration.java
@@ -47,7 +47,7 @@ import static org.mvel2.util.ParseTools.forNameWithInner;
 public class ParserConfiguration implements Serializable {
 
   protected final Map<String, Object> imports = new ConcurrentHashMap<String, Object>();
-  protected final Map<String, Object> reserved = new ConcurrentHashMap<String, Object>();
+  protected final Set<String> reserved = new HashSet<>();
   protected HashSet<String> packageImports;
   protected Map<String, Interceptor> interceptors;
   protected transient ClassLoader classLoader;
@@ -181,7 +181,7 @@ public class ParserConfiguration implements Serializable {
         checkForDynamicImport(name);
   }
   public boolean hasReserved(String name) {
-    return reserved.containsKey(name);
+    return reserved.contains(name);
   }
 
   public void addImport(Class cls) {
@@ -191,8 +191,8 @@ public class ParserConfiguration implements Serializable {
   public void addImport(String name, Class cls) {
     this.imports.put(name, cls);
   }
-  public void addReserved(String name, Class cls) {
-    this.reserved.put(name, cls);
+  public void addReserved(String name) {
+    this.reserved.add(name);
   }
 
   public void addImport(String name, Proto proto) {
@@ -218,7 +218,7 @@ public class ParserConfiguration implements Serializable {
   public Map<String, Object> getImports() {
     return imports;
   }
-  public Map<String, Object> getReserved() {
+  public Set<String> getReserved() {
     return reserved;
   }
 

--- a/src/main/java/org/mvel2/SandboxedParserConfiguration.java
+++ b/src/main/java/org/mvel2/SandboxedParserConfiguration.java
@@ -6,7 +6,6 @@ import org.mvel2.util.TriFunction;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -102,6 +101,10 @@ public class SandboxedParserConfiguration extends ParserConfiguration {
     public void addImport(String name, Class cls) {
         super.addImport(name, cls);
         sanboxedClassLoader.addAllowedClass(cls);
+    }
+   @Override
+    public void addReserved(String name, Class cls) {
+        super.addReserved(name, cls);
     }
 
     @Override

--- a/src/main/java/org/mvel2/SandboxedParserConfiguration.java
+++ b/src/main/java/org/mvel2/SandboxedParserConfiguration.java
@@ -103,8 +103,8 @@ public class SandboxedParserConfiguration extends ParserConfiguration {
         sanboxedClassLoader.addAllowedClass(cls);
     }
    @Override
-    public void addReserved(String name) {
-        super.addReserved(name);
+    public void addNonConvertableClasses(String clazz) {
+        super.addNonConvertableClasses(clazz);
     }
 
     @Override

--- a/src/main/java/org/mvel2/SandboxedParserConfiguration.java
+++ b/src/main/java/org/mvel2/SandboxedParserConfiguration.java
@@ -103,8 +103,8 @@ public class SandboxedParserConfiguration extends ParserConfiguration {
         sanboxedClassLoader.addAllowedClass(cls);
     }
    @Override
-    public void addReserved(String name, Class cls) {
-        super.addReserved(name, cls);
+    public void addReserved(String name) {
+        super.addReserved(name);
     }
 
     @Override

--- a/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -1160,7 +1160,7 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
               ingressName = cExpr.getKnownIngressType().getSimpleName();
               egressName = cExpr.getKnownEgressType().getSimpleName();
             }
-            throw new PropertyAccessException("Invalid type of the " + ((ExecutableAccessor) cExpr).getNode().getName() + " parameter. Expected " + ingressName + " but was " +   egressName, this.expr, this.start, pCtx);
+            throw new PropertyAccessException("Invalid type of the '" + ((ExecutableAccessor) cExpr).getNode().getName() + "' parameter. Expected '" + ingressName + "' but was '" +   egressName + "'.", this.expr, this.start, pCtx);
           }
           args[i] = convert(args[i], paramTypeVarArgsSafe(argParameterTypes, i, m.isVarArgs()));
         }

--- a/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -29,6 +29,7 @@ import org.mvel2.ast.FunctionInstance;
 import org.mvel2.ast.TypeDescriptor;
 import org.mvel2.compiler.Accessor;
 import org.mvel2.compiler.AccessorNode;
+import org.mvel2.compiler.ExecutableAccessor;
 import org.mvel2.compiler.ExecutableLiteral;
 import org.mvel2.compiler.ExecutableStatement;
 import org.mvel2.compiler.PropertyVerifier;
@@ -1149,6 +1150,9 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
           cExpr.computeTypeConversionRule();
         }
         if (!cExpr.isConvertableIngressEgress()) {
+          if (pCtx.getParserConfiguration().hasReserved("TbUtils")) {
+            throw new PropertyAccessException("Invalid type of the " + ((ExecutableAccessor) cExpr).getNode().getName() + " parameter. Expected " +  cExpr.getKnownIngressType().getName() + " but was " +  cExpr.getKnownEgressType().getName(), this.expr, this.start, pCtx);
+          }
           args[i] = convert(args[i], paramTypeVarArgsSafe(argParameterTypes, i, m.isVarArgs()));
         }
       }

--- a/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -1150,7 +1150,7 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
           cExpr.computeTypeConversionRule();
         }
         if (!cExpr.isConvertableIngressEgress()) {
-          if (pCtx.getParserConfiguration().hasReserved(cls.getName())) {
+          if (pCtx.getParserConfiguration().hasNonConvertableClasses(cls.getName())) {
             String ingressName;
             String egressName;
             if (cExpr.getKnownIngressType().getSimpleName().equals(cExpr.getKnownEgressType().getSimpleName())) {

--- a/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -1150,8 +1150,17 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
           cExpr.computeTypeConversionRule();
         }
         if (!cExpr.isConvertableIngressEgress()) {
-          if (pCtx.getParserConfiguration().hasReserved("TbUtils")) {
-            throw new PropertyAccessException("Invalid type of the " + ((ExecutableAccessor) cExpr).getNode().getName() + " parameter. Expected " +  cExpr.getKnownIngressType().getName() + " but was " +  cExpr.getKnownEgressType().getName(), this.expr, this.start, pCtx);
+          if (pCtx.getParserConfiguration().hasReserved(cls.getName())) {
+            String ingressName;
+            String egressName;
+            if (cExpr.getKnownIngressType().getSimpleName().equals(cExpr.getKnownEgressType().getSimpleName())) {
+              ingressName = cExpr.getKnownIngressType().getName();
+              egressName = cExpr.getKnownEgressType().getName();
+            } else {
+              ingressName = cExpr.getKnownIngressType().getSimpleName();
+              egressName = cExpr.getKnownEgressType().getSimpleName();
+            }
+            throw new PropertyAccessException("Invalid type of the " + ((ExecutableAccessor) cExpr).getNode().getName() + " parameter. Expected " + ingressName + " but was " +   egressName, this.expr, this.start, pCtx);
           }
           args[i] = convert(args[i], paramTypeVarArgsSafe(argParameterTypes, i, m.isVarArgs()));
         }

--- a/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
@@ -36,8 +36,7 @@ public class TbUtilsExpressionsTest extends TestCase {
         try {
             TbUtils.register(parserConfig);
             parserConfig.addImport(TbUtilsExpressionsTest.TbUtils.class);
-//            parserConfig.addReserved("TbUtils");
-            parserConfig.addReserved(TbUtils.class.getName());
+            parserConfig.addNonConvertableClasses(TbUtils.class.getName());
         } catch (Exception e) {
             System.out.println("Cannot register functions " +e.getMessage());
         }

--- a/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
@@ -36,7 +36,8 @@ public class TbUtilsExpressionsTest extends TestCase {
         try {
             TbUtils.register(parserConfig);
             parserConfig.addImport(TbUtilsExpressionsTest.TbUtils.class);
-            parserConfig.addReserved("TbUtils", TbUtilsExpressionsTest.TbUtils.class);
+//            parserConfig.addReserved("TbUtils");
+            parserConfig.addReserved(TbUtils.class.getName());
         } catch (Exception e) {
             System.out.println("Cannot register functions " +e.getMessage());
         }
@@ -87,7 +88,7 @@ public class TbUtilsExpressionsTest extends TestCase {
             executeScript(scriptBody);
             fail("Should throw CompileException");
         } catch (CompileException e) {
-            assertTrue(e.getMessage().contains("Invalid type of the " + argument + " parameter. Expected java.lang.String but was java.util.Map"));
+            assertTrue(e.getMessage().contains("Invalid type of the " + argument + " parameter. Expected String but was Map"));
         }
     }
     private Object executeScript(String ex) {

--- a/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
@@ -88,7 +88,7 @@ public class TbUtilsExpressionsTest extends TestCase {
             executeScript(scriptBody);
             fail("Should throw CompileException");
         } catch (CompileException e) {
-            assertTrue(e.getMessage().contains("Invalid type of the " + argument + " parameter. Expected String but was Map"));
+            assertTrue(e.getMessage().contains("Invalid type of the '" + argument + "' parameter. Expected 'String' but was 'Map'"));
         }
     }
     private Object executeScript(String ex) {

--- a/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
@@ -1,0 +1,145 @@
+package org.mvel2.tests.core;
+
+import junit.framework.TestCase;
+import org.mvel2.CompileException;
+import org.mvel2.ExecutionContext;
+import org.mvel2.ParserConfiguration;
+import org.mvel2.ParserContext;
+import org.mvel2.SandboxedParserConfiguration;
+import org.mvel2.execution.ExecutionArrayList;
+import org.mvel2.optimizers.OptimizerFactory;
+import org.mvel2.util.MethodStub;
+
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mvel2.MVEL.compileExpression;
+import static org.mvel2.MVEL.executeTbExpression;
+
+public class TbUtilsExpressionsTest extends TestCase {
+
+    private ExecutionContext ctx;
+    SandboxedParserConfiguration parserConfig;
+    private ExecutionContext currentExecutionContext;
+
+    @Override
+    protected void setUp() throws Exception {
+        OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
+        super.setUp();
+        this.parserConfig = ParserContext.enableSandboxedMode();
+        try {
+            TbUtils.register(parserConfig);
+            parserConfig.addImport(TbUtilsExpressionsTest.TbUtils.class);
+            parserConfig.addReserved("TbUtils", TbUtilsExpressionsTest.TbUtils.class);
+        } catch (Exception e) {
+            System.out.println("Cannot register functions " +e.getMessage());
+        }
+        ctx = new ExecutionContext(parserConfig);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        ParserContext.disableSandboxedMode();
+    }
+
+    public void testStringToBytes_ArgumentTypeIsString_Ok() throws Exception {
+        String expectedStr = "{\"hello\": \"world\"}";
+        String scriptBody = "var input = \"{\\\"hello\\\": \\\"world\\\"}\"; \n" +
+                "var newMsg = stringToBytes(input);\n" +
+                "\n" +
+                "return {msg: newMsg};";
+        LinkedHashMap<String, List<Byte>> expected = new LinkedHashMap<>();
+        List<Byte> expIntList = bytesToList(expectedStr.getBytes());
+        expected.put("msg", expIntList);
+        Object actual = executeScript(scriptBody);
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * The first: ReflectiveAccessorOptimizer
+     * var msgTest = {
+     *     "hello": "world"
+     * };
+     * org.mvel2.execution.ExecutionHashMap
+     *    public String toString() {
+     *         String res = super.toString();
+     *         return "(id=" + id + ") " + res;
+     *     }
+     * return String actualStr = "(id=1) {hello=world}"
+     * Another: MVELRuntime -> MethodAccessor
+     * ! Not have Class[] argParameterTypes = removeExecutionContextParam(parameterTypes); !
+     * @throws Exception
+     */
+    public void testStringToBytes_ArgumentTypeIsNotString_Bad() throws Exception {
+        String argument = "msgTest";
+        String scriptBody = "var " + argument + "  = {\"hello\": \"world\"}; \n" +
+                "var newMsg = stringToBytes(" + argument + ");\n" +
+                "\n" +
+                "return {msg: newMsg};";
+        try {
+            executeScript(scriptBody);
+            fail("Should throw CompileException");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains("Invalid type of the " + argument + " parameter. Expected java.lang.String but was java.util.Map"));
+        }
+    }
+    private Object executeScript(String ex) {
+        return executeScript(ex, new HashMap());
+    }
+
+    private Object executeScript(String ex, Map vars) {
+        return executeScript(ex, vars, new ExecutionContext(this.parserConfig));
+    }
+
+    private Object executeScript(String ex, Map vars, ExecutionContext executionContext) {
+        Serializable compiled = compileExpression(ex, new ParserContext());
+        this.currentExecutionContext = executionContext;
+        return executeTbExpression(compiled, this.currentExecutionContext, vars);
+    }
+
+    private List<Byte> bytesToList(byte[] bytes) {
+        List<Byte> list = new ArrayList<>();
+        for (byte aByte : bytes) {
+            list.add(aByte);
+        }
+        return list;
+    }
+
+    public static class TbUtils {
+
+        private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
+
+        public static void register(ParserConfiguration parserConfig) throws Exception {
+            parserConfig.addImport("stringToBytes", new MethodStub(TbUtils.class.getMethod("stringToBytes",
+                    ExecutionContext.class, String.class)));
+            parserConfig.addImport("stringToBytes", new MethodStub(TbUtils.class.getMethod("stringToBytes",
+                    ExecutionContext.class, String.class, String.class)));
+        }
+
+        public static List<Byte> stringToBytes(ExecutionContext ctx, String str) {
+            byte[] bytes = str.getBytes();
+            return bytesToList(ctx, bytes);
+        }
+
+        public static List<Byte> stringToBytes(ExecutionContext ctx, String str, String charsetName) throws UnsupportedEncodingException {
+            byte[] bytes = str.getBytes(charsetName);
+            return bytesToList(ctx, bytes);
+        }
+
+        private static List<Byte> bytesToList(ExecutionContext ctx, byte[] bytes) {
+            List<Byte> list = new ExecutionArrayList<>(ctx);
+            for (byte aByte : bytes) {
+                list.add(aByte);
+            }
+            return list;
+        }
+
+    }
+}


### PR DESCRIPTION
https://thingsboard-portal.atlassian.net/browse/PROD-2391

##Problem:
### before
 ```
 var msgTest = {
    "hello": "world"
 };
```
- The first: ReflectiveAccessorOptimizer
```
     * org.mvel2.execution.ExecutionHashMap
     *    public String toString() {
     *         String res = super.toString();
     *         return "(id=" + id + ") " + res;
     *     }
```
 **return** _String_ actualStr = "(**id=1) {hello=world}**"
![before_1](https://github.com/thingsboard/tbel/assets/44275303/47e0e31d-7b8a-47ab-bda0-1cb6894d3cee)

-  Another: MVELRuntime -> MethodAccessor
     * ! Not have Class[] argParameterTypes = removeExecutionContextParam(parameterTypes); !

![before_2](https://github.com/thingsboard/tbel/assets/44275303/14f8ef34-cfb6-45db-b7c2-dd169e7d6e70)

### after
![after_02](https://github.com/thingsboard/tbel/assets/44275303/98789f40-33c9-417d-ab0d-3f933bc375c3)


