### PR TITLE
Fix bug hex decimal long

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.thingsboard</groupId>
     <artifactId>tbel</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
 
     <name>tbel</name>
     <url>https://thingsboard.io/</url>

--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -18,33 +18,6 @@
 
 package org.mvel2.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
-import java.lang.ref.WeakReference;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Executable;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.MathContext;
-import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.WeakHashMap;
-
 import org.mvel2.CompileException;
 import org.mvel2.DataTypes;
 import org.mvel2.ExecutionContext;
@@ -74,13 +47,42 @@ import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.ClassImportResolverFactory;
 import org.mvel2.math.MathProcessor;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import static java.lang.Double.parseDouble;
 import static java.lang.String.valueOf;
 import static java.lang.System.arraycopy;
 import static java.lang.Thread.currentThread;
 import static java.nio.ByteBuffer.allocateDirect;
 import static org.mvel2.DataConversion.canConvert;
-import static org.mvel2.DataTypes.*;
+import static org.mvel2.DataTypes.DOUBLE;
+import static org.mvel2.DataTypes.INTEGER;
+import static org.mvel2.DataTypes.LONG;
 import static org.mvel2.MVEL.getDebuggingOutputFileName;
 import static org.mvel2.compiler.AbstractParser.LITERALS;
 import static org.mvel2.integration.ResolverTools.appendFactory;
@@ -1750,7 +1752,14 @@ public class ParseTools {
         }
       }
 
-      return Integer.decode(new String(val, start, offset));
+      try {
+        return Integer.decode(new String(val, start, offset));
+      } catch (NumberFormatException e) {
+        String strVal = new String(val, start, offset).replaceAll("0x", "");
+        return "80000000".equals(strVal) ? Integer.MIN_VALUE :
+                "8000000000000000".equals(strVal) ? Long.MIN_VALUE :
+                        Long.decode(new String(val, start, offset));
+      }
     }
     else if (!isDigit(val[start + offset - 1])) {
       switch (val[start + offset - 1]) {

--- a/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbUtilsExpressionsTest.java
@@ -125,6 +125,17 @@ public class TbUtilsExpressionsTest extends TestCase {
         assertEquals(expected, actual);
     }
 
+    public void testIntToHex_ArgumentIntMoreMax_Ok() throws Exception {
+        String expectedStr = "0xFFD8FFA6";
+        String scriptBody = "\n" +
+                "var newMsg = longToHex(0xFFD8FFA6, true, true);\n" +
+                "return {msg: newMsg}";
+        LinkedHashMap<String, String> expected = new LinkedHashMap<>();
+        expected.put("msg", expectedStr);
+        Object actual = executeScript(scriptBody);
+        assertEquals(expected, actual);
+    }
+
     public void testIntToHex_ArgumentIntMin_Ok() throws Exception {
         String expectedStr = "0x80000000";
         String scriptBody = "\n" +


### PR DESCRIPTION
# Example:
```
var i = 0xFFD8FFA6;
longToHex(i, true, true); 
```

## Before:
<img width="806" alt="зображення" src="https://github.com/user-attachments/assets/287faa6e-2bf7-4ce5-b32e-4d7734a797f5">


## After:
<img width="953" alt="зображення" src="https://github.com/user-attachments/assets/b6dc5a27-2f5e-4626-8ad6-2d0d03a9d456">

