### PR TITLE
tbel_Add_unModifiable_ExecutionArrayList_ExecutionHashMap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.thingsboard</groupId>
     <artifactId>tbel</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
 
     <name>tbel</name>
     <url>https://thingsboard.io/</url>
@@ -256,7 +256,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.8.1</version>
+                <version>3.5.2</version>
             </plugin>
         </plugins>
     </reporting>

--- a/src/main/java/org/mvel2/execution/ExecutionArrayList.java
+++ b/src/main/java/org/mvel2/execution/ExecutionArrayList.java
@@ -11,33 +11,25 @@ import java.util.stream.Collectors;
 
 public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObject {
 
-    private static final Comparator stringCompDesc = new Comparator() {
-        public int compare(Object o1, Object o2) {
-            String first = String.valueOf(o1);
-            String second = String.valueOf(o2);
-            return second.compareTo(first);
-        }
+    private static final Comparator STRING_COMP_DESC = (o1, o2) -> {
+        String first = String.valueOf(o1);
+        String second = String.valueOf(o2);
+        return second.compareTo(first);
     };
-    private static final Comparator numericCompAsc = new Comparator() {
-        public int compare(Object o1, Object o2) {
-            Double first = Double.parseDouble(String.valueOf(o1));
-            Double second = Double.parseDouble(String.valueOf(o2));
-            return first.compareTo(second);
-        }
+    private static final Comparator NUMERIC_COMP_ASC = (o1, o2) -> {
+        Double first = Double.parseDouble(String.valueOf(o1));
+        Double second = Double.parseDouble(String.valueOf(o2));
+        return first.compareTo(second);
     };
-    private static final Comparator numericCompDesc = new Comparator() {
-        public int compare(Object o1, Object o2) {
-            Double first = Double.parseDouble(String.valueOf(o1));
-            Double second = Double.parseDouble(String.valueOf(o2));
-            return second.compareTo(first);
-        }
+    private static final Comparator NUMERIC_COMP_DESC = (o1, o2) -> {
+        Double first = Double.parseDouble(String.valueOf(o1));
+        Double second = Double.parseDouble(String.valueOf(o2));
+        return second.compareTo(first);
     };
-
     private final ExecutionContext executionContext;
-
     private final int id;
-
     private long memorySize = 0;
+    private boolean unmodifiable = false;
 
     public ExecutionArrayList(ExecutionContext executionContext) {
         this.executionContext = executionContext;
@@ -77,6 +69,7 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
 
     @Override
     public boolean addAll(Collection<? extends E> c) {
+        checkModifiable();
         boolean res = super.addAll(c);
         int i = c.size();
         for (E val : c) {
@@ -87,6 +80,7 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
 
     @Override
     public boolean addAll(int index, Collection<? extends E> c) {
+        checkModifiable();
         boolean res = super.addAll(index, c);
         int i = index;
         for (E val : c) {
@@ -97,12 +91,14 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
 
     @Override
     public void add(int index, E e) {
+        checkModifiable();
         super.add(index, e);
         this.memorySize += this.executionContext.onValAdd(this, index, e);
     }
 
     @Override
     public boolean add(E e) {
+        checkModifiable();
         boolean res = super.add(e);
         this.memorySize += this.executionContext.onValAdd(this, size() - 1, e);
         return res;
@@ -110,6 +106,7 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
 
     @Override
     public E remove(int index) {
+        checkModifiable();
         E value = super.remove(index);
         this.memorySize -= this.executionContext.onValRemove(this, index, value);
         return value;
@@ -117,6 +114,7 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
 
     @Override
     public boolean remove(Object value) {
+        checkModifiable();
         int index = super.indexOf(value);
         if (index >= 0) {
             this.remove(index);
@@ -127,6 +125,7 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
 
     @Override
     public E set(int index, E element) {
+        checkModifiable();
         E oldValue = super.set(index, element);
         this.memorySize -= this.executionContext.onValRemove(this, index, oldValue);
         this.memorySize += this.executionContext.onValAdd(this, index, element);
@@ -185,10 +184,11 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
     }
 
     public void sort(boolean asc) {
+        checkModifiable();
         if (validateClazzInArrayIsOnlyString()) {
-            super.sort(asc ? null : stringCompDesc);
+            super.sort(asc ? null : STRING_COMP_DESC);
         } else {
-            super.sort(asc ? numericCompAsc : numericCompDesc);
+            super.sort(asc ? NUMERIC_COMP_ASC : NUMERIC_COMP_DESC);
         }
     }
 
@@ -203,6 +203,7 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
     }
 
     public void reverse() {
+        checkModifiable();
         Collections.reverse(this);
     }
 
@@ -216,6 +217,16 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
         ExecutionArrayList newList = this.slice();
         newList.addAll(c);
         return newList;
+    }
+
+    public ExecutionArrayList toUnmodifiable() {
+        ExecutionArrayList newList = this.slice();
+        newList.unmodifiable = true;
+        return newList;
+    }
+
+    public void unmodifiable() {
+        this.unmodifiable = true;
     }
 
     public List splice(int start) {
@@ -267,6 +278,7 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
     }
 
     public List fill(E value, int start, int end) {
+        checkModifiable();
         start = initStartIndex(start);
         end = initEndIndex(end);
 
@@ -279,7 +291,7 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
     }
 
     public boolean validateClazzInArrayIsOnlyString() {
-        return !super.stream().anyMatch(e -> !(e instanceof String));
+        return super.stream().allMatch(e -> e instanceof String);
     }
 
     private int initStartIndex(int start) {
@@ -292,5 +304,9 @@ public class ExecutionArrayList<E> extends ArrayList<E> implements ExecutionObje
         return end < -this.size() ? 0 :
                 end < 0 ? end + this.size() :
                         Math.min(end, this.size());
+    }
+
+    private void checkModifiable() {
+        if (unmodifiable) throw new UnsupportedOperationException("This ExecutionArrayList is unmodifiable");
     }
 }

--- a/src/main/java/org/mvel2/execution/ExecutionHashMap.java
+++ b/src/main/java/org/mvel2/execution/ExecutionHashMap.java
@@ -13,35 +13,27 @@ import java.util.stream.Collectors;
 
 public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements ExecutionObject {
 
-    private static final Comparator compByValueStringAsc = new Comparator() {
-        public int compare(Object o1, Object o2) {
-            String first = String.valueOf(((Map.Entry) o1).getValue());
-            String second = String.valueOf(((Map.Entry) o2).getValue());
-            return first.compareTo(second);
-        }
+    private static final Comparator COMP_BY_VALUE_STRING_ASC = (o1, o2) -> {
+        String first = String.valueOf(((Entry) o1).getValue());
+        String second = String.valueOf(((Entry) o2).getValue());
+        return first.compareTo(second);
     };
-    private static final Comparator compByValueStringDesc = new Comparator() {
-        public int compare(Object o1, Object o2) {
-            String first = String.valueOf(((Map.Entry) o1).getValue());
-            String second = String.valueOf(((Map.Entry) o2).getValue());
-            return second.compareTo(first);
-        }
+    private static final Comparator COMP_BY_VALUE_STRING_DESC = (o1, o2) -> {
+        String first = String.valueOf(((Entry) o1).getValue());
+        String second = String.valueOf(((Entry) o2).getValue());
+        return second.compareTo(first);
     };
 
-    private static final Comparator compByValueDoubleAsc = new Comparator() {
-        public int compare(Object o1, Object o2) {
-            Double first = Double.parseDouble(String.valueOf(((Map.Entry) o1).getValue()));
-            Double second = Double.parseDouble(String.valueOf(((Map.Entry) o2).getValue()));
-            return first.compareTo(second);
-        }
+    private static final Comparator COMP_BY_VALUE_DOUBLE_ASC = (o1, o2) -> {
+        Double first = Double.parseDouble(String.valueOf(((Entry) o1).getValue()));
+        Double second = Double.parseDouble(String.valueOf(((Entry) o2).getValue()));
+        return first.compareTo(second);
     };
 
-    private static final Comparator compByValueDoubleDesc = new Comparator() {
-        public int compare(Object o1, Object o2) {
-            Double first = Double.parseDouble(String.valueOf(((Map.Entry) o1).getValue()));
-            Double second = Double.parseDouble(String.valueOf(((Map.Entry) o2).getValue()));
-            return second.compareTo(first);
-        }
+    private static final Comparator COMP_BY_VALUE_DOUBLE_DESC = (o1, o2) -> {
+        Double first = Double.parseDouble(String.valueOf(((Entry) o1).getValue()));
+        Double second = Double.parseDouble(String.valueOf(((Entry) o2).getValue()));
+        return second.compareTo(first);
     };
 
     private final ExecutionContext executionContext;
@@ -49,6 +41,8 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
     private final int id;
 
     private long memorySize = 0;
+    private boolean unmodifiable = false;
+    private final String errorUnmodifiableMap = "This Map is unmodifiable";
 
     public ExecutionHashMap(int size, ExecutionContext executionContext) {
         super(size);
@@ -58,6 +52,7 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
 
     @Override
     public V put(K key, V value) {
+        checkModifiable();
         if (containsKey(key)) {
             V prevValue = this.get(key);
             this.memorySize -= this.executionContext.onValRemove(this, key, prevValue);
@@ -74,6 +69,7 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
 
     @Override
     public Set<Entry<K, V>> entrySet() {
+        checkModifiable();
         Set<Entry<K, V>> executionEntries = new LinkedHashSet<>();
         for (Entry<K, V> entry : super.entrySet()) {
             executionEntries.add(new ExecutionEntry<>(entry.getKey(), entry.getValue()));
@@ -83,6 +79,7 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
+        checkModifiable();
         super.putAll(m);
         for (Map.Entry<? extends K, ? extends V> val : m.entrySet()) {
             this.memorySize += this.executionContext.onValAdd(this, val.getKey(), val.getValue());
@@ -91,6 +88,7 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
 
     @Override
     public V putIfAbsent(K key, V value) {
+        checkModifiable();
         if (!super.containsKey(key)) {
             this.memorySize += this.executionContext.onValAdd(this, key, value);
         }
@@ -99,6 +97,7 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
 
     @Override
     public boolean replace(K key, V oldValue, V newValue) {
+        checkModifiable();
         boolean result = super.replace(key, oldValue, newValue);
         if (result) {
             this.memorySize -= this.executionContext.onValRemove(this, key, oldValue);
@@ -109,12 +108,14 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
 
     @Override
     public V replace(K key, V value) {
+        checkModifiable();
         this.memorySize += this.executionContext.onValAdd(this, key, value);
         return super.replace(key, value);
     }
 
     @Override
     public V remove(Object key) {
+        checkModifiable();
         if (containsKey(key)) {
             V value = this.get(key);
             this.memorySize -= this.executionContext.onValRemove(this, key, value);
@@ -132,11 +133,20 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
         return memorySize;
     }
 
+    public Object toUnmodifiable() {
+        ExecutionHashMap newMap = this.slice();
+        newMap.unmodifiable = true;
+        return newMap;
+    }
+
+    public void unmodifiable() {
+        this.unmodifiable = true;
+    }
+
     @Override
     public ExecutionArrayList<V> values() {
         return new ExecutionArrayList<>(super.values(), this.executionContext);
     }
-
 
     public ExecutionArrayList<K> keys() {
         return new ExecutionArrayList<>(super.keySet(), this.executionContext);
@@ -147,6 +157,7 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
     }
 
     public void sortByValue(boolean asc) {
+        checkModifiable();
         Map valueSort = sortMapByValue((HashMap) super.clone(), asc);
         valueSort.keySet().forEach(this::remove);
         this.putAll(valueSort);
@@ -157,6 +168,7 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
     }
 
     public void sortByKey(boolean asc) {
+        checkModifiable();
         ExecutionArrayList keys = this.keys();
         keys.sort(asc);
         HashMap keysMapSort = new LinkedHashMap();
@@ -165,15 +177,25 @@ public class ExecutionHashMap<K, V> extends LinkedHashMap<K, V> implements Execu
         this.putAll(keysMapSort);
     }
 
+    public ExecutionHashMap slice() {
+        return new ExecutionHashMap<>(this.size(), this.executionContext);
+    }
+
     private <K, V extends Comparable<? super V>> Map<K, V> sortMapByValue(Map<K, V> map, boolean asc) {
+        checkModifiable();
         boolean isString = this.values().validateClazzInArrayIsOnlyString();
         Comparator<? super Map.Entry> cmp =
                 isString ?
-                        asc ? compByValueStringAsc : compByValueStringDesc :
-                        asc ? compByValueDoubleAsc : compByValueDoubleDesc;
+                        asc ? COMP_BY_VALUE_STRING_ASC : COMP_BY_VALUE_STRING_DESC :
+                        asc ? COMP_BY_VALUE_DOUBLE_ASC : COMP_BY_VALUE_DOUBLE_DESC;
         return map.entrySet()
                 .stream()
                 .sorted(cmp)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
     }
+
+    private void checkModifiable() {
+        if (unmodifiable) throw new UnsupportedOperationException("This ExecutionHashMap is unmodifiable");
+    }
 }
+

--- a/src/test/java/org/mvel2/tests/core/TbExpressionsTest.java
+++ b/src/test/java/org/mvel2/tests/core/TbExpressionsTest.java
@@ -3743,6 +3743,118 @@ public class TbExpressionsTest extends TestCase {
         assertEquals(expected, result.toString());
     }
 
+    /**
+     *      ExecutionArrayList: unmodifiable/toUnmodifiable
+     *      add
+     *      addAll(Collection<? extends E> c)
+     *      addAll(int index, Collection<? extends E> c) {
+     *      public boolean add(E e) {
+     *      add(int index, E e) {
+     *      remove(int index)
+     *      remove(Object value)
+     *      set(int index, E element)
+     *      sort(),
+     *      sort(boolean asc)
+     *      reverse()
+     *      fill
+     */
+    public void testExecutionArrayList_Unmodifiable_Add() {
+        String errorArray = "This ExecutionArrayList is unmodifiable";
+        String body = "var msg = {};\n" +
+                "var original = [];\n" +
+                "original.unmodifiable;\n" +
+                "original.add(0x35);\n" +
+                "msg.result = original;\n" +
+                "return {msg: msg};";
+        try {
+            executeScript(body);
+            fail("Should throw CompileException");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains(errorArray));
+        }
+        body = "var msg = {};\n" +
+                "var original = [];\n" +
+                "original.add(0x67);\n" +
+                "original.unmodifiable;\n" +
+                "original.add(0x35);\n" +
+                "msg.result = original;\n" +
+                "return {msg: msg};";
+        try {
+            executeScript(body);
+            fail("Should throw CompileException");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains(errorArray));
+        }
+        body = "var msg = {};\n" +
+                "var original = [1, 2, 3, 4, 5];\n" +
+                "original.add(0x67);\n" +
+                "var modifiable = original.toUnmodifiable;\n" +
+                "modifiable.add(0x35);\n" +
+                "msg.result = modifiable;\n" +
+                "return {msg: msg};";
+        try {
+            executeScript(body);
+            fail("Should throw CompileException");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains(errorArray));
+        }
+    }
+
+    /**
+     *      ExecutionHashMap: unmodifiable/toUnmodifiable
+     *      put(K key, V value)
+     *      Set<Entry<K, V>> entrySet()
+     *      putAll(Map<? extends K, ? extends V> m)
+     *      putIfAbsent(K key, V value)
+     *      replace(K key, V oldValue, V newValue)
+     *      replace(K key, V value)
+     *      remove(Object key)
+     *      sortByValue
+     *      sortByKey
+     *      sortMapByValue(Map<K, V> map, boolean asc)
+     */
+
+    public void testExecutionHashMap_Unmodifiable_Put() {
+        String errorArray = "This ExecutionHashMap is unmodifiable";
+        String body = "var msg = {};\n" +
+                "var original = {};\n" +
+                "original.unmodifiable;\n" +
+                "original.putIfAbsent(\"temperature1\", 73);\n" +
+                "msg.result = original;\n" +
+                "return {msg: msg};";
+        try {
+            executeScript(body);
+            fail("Should throw CompileException");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains(errorArray));
+        }
+        body = "var msg = {};\n" +
+                "var original = {};\n" +
+                "original.humidity = 73;\n" +
+                "original.unmodifiable;\n" +
+                "original.putIfAbsent(\"temperature1\", 73);\n" +
+                "msg.result = original;\n" +
+                "return {msg: msg};";
+        try {
+            executeScript(body);
+            fail("Should throw CompileException");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains(errorArray));
+        }body = "var msg = {};\n" +
+                "var original = {\"temperature\": 42, \"nested\" : \"508\"};\n" +
+                "original.humidity = 73;\n" +
+                "original.unmodifiable;\n" +
+                "original.putIfAbsent(\"temperature1\", 73);\n" +
+                "msg.result = original;\n" +
+                "return {msg: msg};";
+        try {
+            executeScript(body);
+            fail("Should throw CompileException");
+        } catch (CompileException e) {
+            assertTrue(e.getMessage().contains(errorArray));
+        }
+    }
+
     private Object executeScript(String ex, Map vars, ExecutionContext executionContext, long timeoutMs) throws Exception {
         final CountDownLatch countDown = new CountDownLatch(1);
         AtomicReference<Object> result = new AtomicReference<>();


### PR DESCRIPTION
## New property: unmodifiable. It is not possible to add or modify elements, similar to Collections.unmodifiableList (Collections.immutableList).

### Methods that cannot be applied:
#### ExecutionArrayList: unmodifiable/toUnmodifiable
```
     *      add
     *      addAll(Collection<? extends E> c)
     *      addAll(int index, Collection<? extends E> c) {
     *      public boolean add(E e) {
     *      add(int index, E e) {
     *      remove(int index)
     *      remove(Object value)
     *      set(int index, E element)
     *      sort(),
     *      sort(boolean asc)
     *      reverse()
     *      fill
```
#### ExecutionHashMap: unmodifiable/toUnmodifiable
```
     *      put(K key, V value)
     *      Set<Entry<K, V>> entrySet()
     *      putAll(Map<? extends K, ? extends V> m)
     *      putIfAbsent(K key, V value)
     *      replace(K key, V oldValue, V newValue)
     *      replace(K key, V value)
     *      remove(Object key)
     *      sortByValue
     *      sortByKey
     *      sortMapByValue(Map<K, V> map, boolean asc)
```
![зображення](https://github.com/user-attachments/assets/f8dd0cde-ca8e-47c9-ade1-f9806874d1dd)

